### PR TITLE
define supported platform to suppress kitchen warning

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,3 +19,5 @@ depends          'database'
 depends          'hostsfile'
 depends          'apache2'
 depends          'runit'
+
+supports	 'centos', '~>6.0'


### PR DESCRIPTION
Without this, I get an error running kitchen:

`$$$$$$ No platforms supported in metadata.rb;showing all available platforms`